### PR TITLE
EDIT: Update dependency glsl-mode v2.0 -> v2.4

### DIFF
--- a/company-glsl.el
+++ b/company-glsl.el
@@ -8,7 +8,7 @@
 ;; Created: 08 October 2017
 ;; Original Created: 11 January 2015
 ;; Version: 0.2
-;; Package-Requires: ((company "0.9.4") (glsl-mode "2.0") (emacs "24.4"))
+;; Package-Requires: ((company "0.9.4") (glsl-mode "2.4") (emacs "24.4"))
 ;; URL: https://github.com/guidoschmidt/company-glsl
 
 ;;; License:
@@ -166,8 +166,8 @@
 (defun company-glsl--extended-candidates (arg)
   "Extends parsed candidates based on ARG with type/modifier/builtin lists as provided by ‘glsl-mode’."
   (let ((candidates (append glsl-type-list
-                            glsl-modifier-list
-                            glsl-deprecated-modifier-list
+                            glsl-qualifier-list
+                            glsl-deprecated-qualifier-list
                             glsl-builtin-list
                             glsl-deprecated-builtin-list
                             (company-glsl--candidates arg))))


### PR DESCRIPTION
Good evening!

I was trying to use `company-glsl` (version 20171015.1749) and noticed that it didn't work with latest version of `glsl-mode` (version 20200501.2304). I only got completion error:

```
Company: backend company-glsl error "Symbol’s value as variable is void: glsl-modifier-list" with args (candidates layo)
```

**How to reproduce:**
1) Type `layo`
2) `M-x company-glsl`
3) Get error message `Company: backend company-glsl error "Symbol’s value as variable is void: glsl-modifier-list" with args (candidates layo)`

**Possible reason:**
`glsl-mode` v2.4 made some changes (https://github.com/jimhourihan/glsl-mode/commit/9d17df5015c64bb2bafdb7e6c4ed785f01e381d5) where `glsl-modifier-list` was renamed to `glsl-qualifier-list` (same for `glsl-deprecated-modifier-list` -> `glsl-deprecated-qualifier-list`).

**Fix:**
Changing these values in `candidates` seemed to make it work with `glsl-mode` v2.4.

Would it be good idea to make `company-glsl` work with the latest `glsl-mode`? This was my first time trying to work with GLSL-files (and `company-glsl`) and I would appreciate if you have some time to check if there's something I missed?

Thank you!

Best regards, Valtteri.